### PR TITLE
Plugin name update & extra guidance for deploying custom images

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Refer to
     }
     ```
 
-      If you hit the [storage scalability limits](https://docs.microsoft.com/en-us/azure/storage/storage-scalability-targets) for your custom images on one storage account you should consider using the agent [temporary storage](https://blogs.msdn.microsoft.com/mast/2013/12/06/understanding-the-temporary-drive-on-windows-azure-virtual-machines) or creating multiple storage accounts and spread your agents across multiple templates with the same label.
+      If you hit the [storage scalability limits](https://docs.microsoft.com/en-us/azure/storage/storage-scalability-targets) for your custom images on the storage account where the VHD resides, you should consider using the agent's [temporary storage](https://blogs.msdn.microsoft.com/mast/2013/12/06/understanding-the-temporary-drive-on-windows-azure-virtual-machines) or copy your custom image in multiple storage accounts and use multiple VM templates with the same label within the same agent cloud.
 
       For more details about how to prepare custom images, refer to the below links:
       * [Capture Windows Image](http://azure.microsoft.com/en-us/documentation/articles/virtual-machines-capture-image-windows-server/)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# azure-vm-agents-plugin
+# azure-vm-agents
 
 
 Jenkins Plugin to create Azure VM agents (on Azure ARM).

--- a/README.md
+++ b/README.md
@@ -128,6 +128,8 @@ Refer to
     }
     ```
 
+      If you hit the [storage scalability limits](https://docs.microsoft.com/en-us/azure/storage/storage-scalability-targets) for your custom images on one storage account you should consider using the agent [temporary storage](https://blogs.msdn.microsoft.com/mast/2013/12/06/understanding-the-temporary-drive-on-windows-azure-virtual-machines) or creating multiple storage accounts and spread your agents across multiple templates with the same label.
+
       For more details about how to prepare custom images, refer to the below links:
       * [Capture Windows Image](http://azure.microsoft.com/en-us/documentation/articles/virtual-machines-capture-image-windows-server/)
       * [Capture Linux Image](http://azure.microsoft.com/en-us/documentation/articles/virtual-machines-linux-capture-image/)

--- a/src/main/resources/com/microsoft/azure/AzureVMAgentPostBuildAction/config.jelly
+++ b/src/main/resources/com/microsoft/azure/AzureVMAgentPostBuildAction/config.jelly
@@ -1,7 +1,7 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 	<f:section title="${%PostBuild_Action_Azure_Agent}">
-		<f:entry title="${%Perform_The_Following_On_Completion}" field="agentPostBuildAction" help="/plugin/azure-vm-agents-plugin/help-agentPostBuildAction.html">
+		<f:entry title="${%Perform_The_Following_On_Completion}" field="agentPostBuildAction" help="/plugin/azure-vm-agents/help-agentPostBuildAction.html">
             <f:select />
 		</f:entry>
 	</f:section>

--- a/src/main/resources/com/microsoft/azure/AzureVMAgentTemplate/config.jelly
+++ b/src/main/resources/com/microsoft/azure/AzureVMAgentTemplate/config.jelly
@@ -2,116 +2,116 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:c="/lib/credentials" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <table width="100%">
     <f:section title="${%General_Configuration}">
-      <f:entry title="${%Template_Name}" field="templateName" help="/plugin/azure-vm-agents-plugin/help-templateName.html">
-        <f:textbox />
-      </f:entry>  
-		 	 
-      <f:entry title="${%Template_Description}" field="templateDesc" help="/plugin/azure-vm-agents-plugin/help-templateDesc.html">
+      <f:entry title="${%Template_Name}" field="templateName" help="/plugin/azure-vm-agents/help-templateName.html">
         <f:textbox />
       </f:entry>
-		 	 
-      <f:entry title="${%Labels}" field="labels" help="/plugin/azure-vm-agents-plugin/help-labels.html">
+
+      <f:entry title="${%Template_Description}" field="templateDesc" help="/plugin/azure-vm-agents/help-templateDesc.html">
         <f:textbox />
       </f:entry>
-		 	  
-      <f:entry title="${%Location}" field="location" help="/plugin/azure-vm-agents-plugin/help-location.html">
+
+      <f:entry title="${%Labels}" field="labels" help="/plugin/azure-vm-agents/help-labels.html">
+        <f:textbox />
+      </f:entry>
+
+      <f:entry title="${%Location}" field="location" help="/plugin/azure-vm-agents/help-location.html">
         <f:select />
       </f:entry>
-		  
-      <f:entry title="${%Virtual_Machine_Size}" field="virtualMachineSize" help="/plugin/azure-vm-agents-plugin/help-virtualMachineSize.html">
+
+      <f:entry title="${%Virtual_Machine_Size}" field="virtualMachineSize" help="/plugin/azure-vm-agents/help-virtualMachineSize.html">
         <f:select />
       </f:entry>
-		  		
-      <f:entry title="${%Storage_Account_Name}" field="storageAccountName" help="/plugin/azure-vm-agents-plugin/help-storageAccountName.html">
+
+      <f:entry title="${%Storage_Account_Name}" field="storageAccountName" help="/plugin/azure-vm-agents/help-storageAccountName.html">
         <f:textbox />
       </f:entry>
-		  		
-      <f:entry title="${%RetentionTimeInMin}" field="retentionTimeInMin" help="/plugin/azure-vm-agents-plugin/help-retentionTimeInMin.html">
+
+      <f:entry title="${%RetentionTimeInMin}" field="retentionTimeInMin" help="/plugin/azure-vm-agents/help-retentionTimeInMin.html">
         <f:textbox default="60" />
       </f:entry>
-				
-      <f:entry title="${%shutdownOnIdle}" field="shutdownOnIdle"  help="/plugin/azure-vm-agents-plugin/help-shutdownOnIdle.html">
+
+      <f:entry title="${%shutdownOnIdle}" field="shutdownOnIdle"  help="/plugin/azure-vm-agents/help-shutdownOnIdle.html">
         <f:checkbox/>
       </f:entry>
-				
-      <f:slave-mode name="useAgentAlwaysIfAvail" node="${instance}" help="/plugin/azure-vm-agents-plugin/help-slaveMode.html" default="EXCLUSIVE"/>
+
+      <f:slave-mode name="useAgentAlwaysIfAvail" node="${instance}" help="/plugin/azure-vm-agents/help-slaveMode.html" default="EXCLUSIVE"/>
     </f:section>
-		 	 
+
     <f:section title="${%Image_Configuration}">
-      <f:radioBlock name="imageReferenceType" value="custom" title="${%Custom_Image}" checked="${instance.isType('custom')}" help="/plugin/azure-vm-agents-plugin/help-image.html" inline="true">
-        <f:entry title="${%Image}" field="image" help="/plugin/azure-vm-agents-plugin/help-image.html">
+      <f:radioBlock name="imageReferenceType" value="custom" title="${%Custom_Image}" checked="${instance.isType('custom')}" help="/plugin/azure-vm-agents/help-image.html" inline="true">
+        <f:entry title="${%Image}" field="image" help="/plugin/azure-vm-agents/help-image.html">
           <f:textbox />
         </f:entry>
       </f:radioBlock>
 
-      <f:radioBlock name="imageReferenceType" value="reference" title="${%Marketplace_Image}" checked="${instance.isType('reference')}" help="/plugin/azure-vm-agents-plugin/help-imageReference.html" inline="true">
-        <f:entry title="${%Image_Publisher}" field="imagePublisher" help="/plugin/azure-vm-agents-plugin/help-imageReference.html">
+      <f:radioBlock name="imageReferenceType" value="reference" title="${%Marketplace_Image}" checked="${instance.isType('reference')}" help="/plugin/azure-vm-agents/help-imageReference.html" inline="true">
+        <f:entry title="${%Image_Publisher}" field="imagePublisher" help="/plugin/azure-vm-agents/help-imageReference.html">
           <f:textbox />
         </f:entry>
-        <f:entry title="${%Image_Offer}" field="imageOffer" help="/plugin/azure-vm-agents-plugin/help-imageReference.html">
+        <f:entry title="${%Image_Offer}" field="imageOffer" help="/plugin/azure-vm-agents/help-imageReference.html">
           <f:textbox />
         </f:entry>
-        <f:entry title="${%Image_Sku}" field="imageSku" help="/plugin/azure-vm-agents-plugin/help-imageReference.html">
+        <f:entry title="${%Image_Sku}" field="imageSku" help="/plugin/azure-vm-agents/help-imageReference.html">
           <f:textbox />
         </f:entry>
-        <f:entry title="${%Image_Version}" field="imageVersion" help="/plugin/azure-vm-agents-plugin/help-imageReference.html">
+        <f:entry title="${%Image_Version}" field="imageVersion" help="/plugin/azure-vm-agents/help-imageReference.html">
           <f:textbox default="latest"/>
         </f:entry>
       </f:radioBlock>
-			
 
-      <f:entry title="${%Os_Type}" field="osType" help="/plugin/azure-vm-agents-plugin/help-osType.html">
+
+      <f:entry title="${%Os_Type}" field="osType" help="/plugin/azure-vm-agents/help-osType.html">
         <f:select />
       </f:entry>
-      <f:entry title="${%Launch_Method}" field="agentLaunchMethod" help="/plugin/azure-vm-agents-plugin/help-agentLaunchMethod.html">
+      <f:entry title="${%Launch_Method}" field="agentLaunchMethod" help="/plugin/azure-vm-agents/help-agentLaunchMethod.html">
         <f:select />
       </f:entry>
-      
-      <f:entry title="${%Admin_Credentials}" field="credentialsId" help="/plugin/azure-vm-agents-plugin/help-credentials.html">
+
+      <f:entry title="${%Admin_Credentials}" field="credentialsId" help="/plugin/azure-vm-agents/help-credentials.html">
         <c:select expressionAllowed="false"/>
       </f:entry>
-      
+
       <f:section title="${%Initialization_Configuration}">
-        <f:entry title="${%Init_Script}" field="initScript" help="/plugin/azure-vm-agents-plugin/help-initScript.html">
+        <f:entry title="${%Init_Script}" field="initScript" help="/plugin/azure-vm-agents/help-initScript.html">
           <f:textarea />
         </f:entry>
 
-        <f:entry title="${%Execute_Init_Script_As_Root}" field="executeInitScriptAsRoot" help="/plugin/azure-vm-agents-plugin/help-executeInitScriptAsRoot.html">
+        <f:entry title="${%Execute_Init_Script_As_Root}" field="executeInitScriptAsRoot" help="/plugin/azure-vm-agents/help-executeInitScriptAsRoot.html">
           <f:checkbox default="true"/>
         </f:entry>
-        
-        <f:entry title="${%Do_Not_Use_Machine_If_Init_Fails}" field="doNotUseMachineIfInitFails" help="/plugin/azure-vm-agents-plugin/help-doNotUseMachineIfInitFails.html">
+
+        <f:entry title="${%Do_Not_Use_Machine_If_Init_Fails}" field="doNotUseMachineIfInitFails" help="/plugin/azure-vm-agents/help-doNotUseMachineIfInitFails.html">
           <f:checkbox default="true"/>
         </f:entry>
       </f:section>
     </f:section>
-		
+
     <f:advanced>
-      <f:entry title="${%VirtualNetwork_Name}" field="virtualNetworkName" help="/plugin/azure-vm-agents-plugin/help-virtualNetworkName.html">
-        <f:textbox />
-      </f:entry>
-				
-      <f:entry title="${%Subnet_Name}" field="subnetName" help="/plugin/azure-vm-agents-plugin/help-subnetName.html">
-        <f:textbox />
-      </f:entry>
-								 
-      <f:entry title="${%Agent_Workspace}" field="agentWorkspace" help="/plugin/azure-vm-agents-plugin/help-agentWorkspace.html">
-        <f:textbox />
-      </f:entry>
-		    	
-      <f:entry title="${%JVM_Options}" field="jvmOptions" help="/plugin/azure-vm-agents-plugin/help-jvmOptions.html">
+      <f:entry title="${%VirtualNetwork_Name}" field="virtualNetworkName" help="/plugin/azure-vm-agents/help-virtualNetworkName.html">
         <f:textbox />
       </f:entry>
 
-      <f:entry title="${%noOfParallelJobs}" field="noOfParallelJobs" help="/plugin/azure-vm-agents-plugin/help-noOfParallelJobs.html">
+      <f:entry title="${%Subnet_Name}" field="subnetName" help="/plugin/azure-vm-agents/help-subnetName.html">
+        <f:textbox />
+      </f:entry>
+
+      <f:entry title="${%Agent_Workspace}" field="agentWorkspace" help="/plugin/azure-vm-agents/help-agentWorkspace.html">
+        <f:textbox />
+      </f:entry>
+
+      <f:entry title="${%JVM_Options}" field="jvmOptions" help="/plugin/azure-vm-agents/help-jvmOptions.html">
+        <f:textbox />
+      </f:entry>
+
+      <f:entry title="${%noOfParallelJobs}" field="noOfParallelJobs" help="/plugin/azure-vm-agents/help-noOfParallelJobs.html">
         <f:textbox default="${descriptor.getDefaultNoOfExecutors()}" />
       </f:entry>
-				
-      <f:entry title="${%Template_Is_Disabled}" field="templateDisabled"  help="/plugin/azure-vm-agents-plugin/help-templateDisabled.html">
+
+      <f:entry title="${%Template_Is_Disabled}" field="templateDisabled"  help="/plugin/azure-vm-agents/help-templateDisabled.html">
         <f:checkbox/>
       </f:entry>
-		  	 	
-      <f:entry title="${%Template_Status_Details}" field="templateStatusDetails" help="/plugin/azure-vm-agents-plugin/help-templateStatusDetails.html">
+
+      <f:entry title="${%Template_Status_Details}" field="templateStatusDetails" help="/plugin/azure-vm-agents/help-templateStatusDetails.html">
         <f:textarea />
       </f:entry>
     </f:advanced>
@@ -120,7 +120,7 @@
         <f:repeatableDeleteButton value="${%Delete_Template}" />
       </div>
     </f:entry>
-    <f:validateButton title="${%Verify_Template}" progress="${%Verifying_Template_MSG}" method="verifyConfiguration" 
+    <f:validateButton title="${%Verify_Template}" progress="${%Verifying_Template_MSG}" method="verifyConfiguration"
           with="azureCredentialsId,resourceGroupName,maxVirtualMachinesLimit,deploymentTimeout,templateName,labels,location,virtualMachineSize,storageAccountName,noOfParallelJobs,image,osType,imagePublisher,imageOffer,imageSku,imageVersion,agentLaunchMethod,initScript,credentialsId,virtualNetworkName,subnetName,retentionTimeInMin,jvmOptions" />
   </table>
 </j:jelly>

--- a/src/main/resources/com/microsoft/azure/AzureVMCloud/config.jelly
+++ b/src/main/resources/com/microsoft/azure/AzureVMCloud/config.jelly
@@ -1,29 +1,29 @@
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" 
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
          xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:c="/lib/credentials">
 
   <f:section title="${%Azure_Profile_Configuration}">
-    <f:entry title="${%Azure_Credentials}" field="azureCredentialsId" help="/plugin/azure-vm-agents-plugin/help-azureCredentials.html">
+    <f:entry title="${%Azure_Credentials}" field="azureCredentialsId" help="/plugin/azure-vm-agents/help-azureCredentials.html">
       <c:select expressionAllowed="false"/>
     </f:entry>
-    <f:entry title="${%Max_Virtual_Machines_Limit}" field="maxVirtualMachinesLimit" help="/plugin/azure-vm-agents-plugin/help-maxVirtualMachinesLimit.html">
+    <f:entry title="${%Max_Virtual_Machines_Limit}" field="maxVirtualMachinesLimit" help="/plugin/azure-vm-agents/help-maxVirtualMachinesLimit.html">
       <f:textbox default="${descriptor.getDefaultMaxVMLimit()}" />
     </f:entry>
-    
-    <f:entry title="${%Deployment_Timeout}" field="deploymentTimeout" help="/plugin/azure-vm-agents-plugin/help-deploymentTimeout.html">
+
+    <f:entry title="${%Deployment_Timeout}" field="deploymentTimeout" help="/plugin/azure-vm-agents/help-deploymentTimeout.html">
       <f:textbox default="${descriptor.getDefaultDeploymentTimeout()}" />
     </f:entry>
-    
-    <f:entry title="${%Resource_Group_Name}" field="resourceGroupName" help="/plugin/azure-vm-agents-plugin/help-resourceGroupName.html">
+
+    <f:entry title="${%Resource_Group_Name}" field="resourceGroupName" help="/plugin/azure-vm-agents/help-resourceGroupName.html">
       <f:textbox default="${descriptor.getDefaultResourceGroupName()}" />
     </f:entry>
-    <f:validateButton title="${%Verify_Configuration}" progress="${%Verifying}" method="verifyConfiguration" 
+    <f:validateButton title="${%Verify_Configuration}" progress="${%Verifying}" method="verifyConfiguration"
           with="azureCredentialsId,maxVirtualMachinesLimit,deploymentTimeout,resourceGroupName" />
   </f:section>
-	
+
   <f:entry title="${%Azure_Virtual_Machine_Template}" description="${%Azure_Virtual_Machine_Template_desc}">
     <f:repeatable field="instTemplates">
       <st:include page="config.jelly" class="${descriptor.clazz}" />
-    </f:repeatable>		 
+    </f:repeatable>
   </f:entry>
 </j:jelly>

--- a/src/main/resources/com/microsoft/azure/util/AzureCredentials/credentials.jelly
+++ b/src/main/resources/com/microsoft/azure/util/AzureCredentials/credentials.jelly
@@ -2,22 +2,22 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:st="jelly:stapler" xmlns:d="jelly:define">
     <j:set var="uniqueId" value="${h.generateId()}" />
-    <f:entry title="${%Subscription ID}" field="subscriptionId" help="/plugin/azure-vm-agents-plugin/help-subscriptionId.html">
+    <f:entry title="${%Subscription ID}" field="subscriptionId" help="/plugin/azure-vm-agents/help-subscriptionId.html">
       <f:password />
     </f:entry>
-    <f:entry title="${%Client ID}" field="clientId" help="/plugin/azure-vm-agents-plugin/help-clientId.html">
+    <f:entry title="${%Client ID}" field="clientId" help="/plugin/azure-vm-agents/help-clientId.html">
       <f:password />
     </f:entry>
-    <f:entry title="${%Client Secret}" field="clientSecret" help="/plugin/azure-vm-agents-plugin/help-clientSecret.html">
+    <f:entry title="${%Client Secret}" field="clientSecret" help="/plugin/azure-vm-agents/help-clientSecret.html">
       <f:password />
     </f:entry>
-    <f:entry title="${%OAuth 2.0 Token Endpoint}" field="oauth2TokenEndpoint" help="/plugin/azure-vm-agents-plugin/help-oauth2TokenEndpoint.html">
+    <f:entry title="${%OAuth 2.0 Token Endpoint}" field="oauth2TokenEndpoint" help="/plugin/azure-vm-agents/help-oauth2TokenEndpoint.html">
       <f:password />
     </f:entry>
-    <f:entry title="${%Management Service URL}" field="serviceManagementURL" help="/plugin/azure-vm-agents-plugin/help-serviceManagementURL.html">
+    <f:entry title="${%Management Service URL}" field="serviceManagementURL" help="/plugin/azure-vm-agents/help-serviceManagementURL.html">
       <f:textbox default="${descriptor.getDefaultserviceManagementURL()}"/>
     </f:entry>
     <st:include page="id-and-description" class="${descriptor.clazz}"/>
-    <f:validateButton title="${%Verify Configuration}" progress="${%Verifying}" method="verifyConfiguration" 
+    <f:validateButton title="${%Verify Configuration}" progress="${%Verifying}" method="verifyConfiguration"
           with="subscriptionId,clientId,clientSecret,oauth2TokenEndpoint,serviceManagementURL" />
 </j:jelly>

--- a/src/main/webapp/help-image.html
+++ b/src/main/webapp/help-image.html
@@ -3,4 +3,5 @@
     Your custom image has to be available into the same storage account in which you are going to create agent nodes.<br />
     <br />
     e.g. https://jenkinsarm.blob.core.windows.net/system/Microsoft.Compute/Images/vhds/jenkinsvm5-osDisk.c68efe70-4b40-450e-a8b6-3d10b7d1665f.vhd<br /><br />
+    If you hit the <a target="_blank" href="https://docs.microsoft.com/en-us/azure/storage/storage-scalability-targets">storage scalability limits</a> for your custom images on one storage account you should consider using the agents <a target="_blank" href="https://blogs.msdn.microsoft.com/mast/2013/12/06/understanding-the-temporary-drive-on-windows-azure-virtual-machines/">temporary storage</a> or creating multiple storage accounts and spread your agents across multiple templates with the same label.
 </div>

--- a/src/main/webapp/help-image.html
+++ b/src/main/webapp/help-image.html
@@ -1,7 +1,7 @@
 <div>
-	Enter an URI of a custom user image and operating system type.<br />
+    Enter an URI of a custom user image and operating system type.<br />
     Your custom image has to be available into the same storage account in which you are going to create agent nodes.<br />
     <br />
     e.g. https://jenkinsarm.blob.core.windows.net/system/Microsoft.Compute/Images/vhds/jenkinsvm5-osDisk.c68efe70-4b40-450e-a8b6-3d10b7d1665f.vhd<br /><br />
-    If you hit the <a target="_blank" href="https://docs.microsoft.com/en-us/azure/storage/storage-scalability-targets">storage scalability limits</a> for your custom images on one storage account you should consider using the agents <a target="_blank" href="https://blogs.msdn.microsoft.com/mast/2013/12/06/understanding-the-temporary-drive-on-windows-azure-virtual-machines/">temporary storage</a> or creating multiple storage accounts and spread your agents across multiple templates with the same label.
+    If you hit the <a target="_blank" href="https://docs.microsoft.com/en-us/azure/storage/storage-scalability-targets">storage scalability limits</a> for your custom images on the storage account where the VHD resides, you should consider using the agent's <a target="_blank" href="https://blogs.msdn.microsoft.com/mast/2013/12/06/understanding-the-temporary-drive-on-windows-azure-virtual-machines/">temporary storage</a> or copy your custom image in multiple storage accounts and use multiple VM templates with the same label within the same agent cloud.
 </div>


### PR DESCRIPTION
* updated the plugin name to not have the word 'plugin' (most of the files changed)
* updated the contextual help and readme to include guidance on how to deploy multiple agents from the same custom image.